### PR TITLE
feat: use random string instead of date for logouts

### DIFF
--- a/src/backend/src/account/account.entity.ts
+++ b/src/backend/src/account/account.entity.ts
@@ -9,14 +9,15 @@ import {
   Property,
 } from 'mikro-orm';
 import { User } from '../user/user.entity';
+import crypto from 'crypto';
 
 @Entity()
 export class Account extends BaseEntity<Account, 'id'> {
   @PrimaryKey()
   id!: number;
 
-  @Property({ nullable: true })
-  logoutAt?: Date;
+  @Property({ hidden: true })
+  logoutHash: string = crypto.randomBytes(10).toString('hex');
 
   @Property()
   createdAt: Date = new Date();

--- a/src/backend/src/account/dtos/update-account.dto.ts
+++ b/src/backend/src/account/dtos/update-account.dto.ts
@@ -1,7 +1,7 @@
-import { IsDateString, IsOptional } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateAccountDTO {
   @IsOptional()
-  @IsDateString()
-  logoutAt?: Date;
+  @IsString()
+  logoutHash?: string;
 }

--- a/src/backend/src/auth/auth.module.ts
+++ b/src/backend/src/auth/auth.module.ts
@@ -1,6 +1,4 @@
 import { forwardRef, Global, Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { JwtModule } from '@nestjs/jwt';
 import { AccountModule } from '../account/account.module';
 import { ACCESS_CONTROL_TOKEN } from '../app.constants';
 import AccessControl from '../app.roles';
@@ -17,17 +15,7 @@ const ACProvider = {
 
 @Global()
 @Module({
-  imports: [
-    JwtModule.registerAsync({
-      imports: [ConfigModule],
-      useFactory: async (config: ConfigService) => ({
-        secret: config.get('SECRET'),
-      }),
-      inject: [ConfigService],
-    }),
-    forwardRef(() => UserModule),
-    forwardRef(() => AccountModule),
-  ],
+  imports: [forwardRef(() => UserModule), forwardRef(() => AccountModule)],
   providers: [AuthService, ACProvider, LocalStrategy, TokenStrategy],
   controllers: [AuthController],
   exports: [AuthService, ACProvider],

--- a/src/backend/src/auth/strategies/local.strategy.ts
+++ b/src/backend/src/auth/strategies/local.strategy.ts
@@ -5,8 +5,7 @@ import {
 } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
-import { AuthService } from '../auth.service';
-import { AuthRequest } from './token.strategy';
+import { AuthRequest, AuthService } from '../auth.service';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {

--- a/src/backend/src/auth/strategies/token.strategy.ts
+++ b/src/backend/src/auth/strategies/token.strategy.ts
@@ -1,65 +1,30 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  UnauthorizedException,
-} from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Account } from '../../account/account.entity';
-import { AccountService } from '../../account/account.service';
-import { User } from '../../user/user.entity';
-import { UserService } from '../../user/user.service';
+import { AuthRequest, AuthService } from '../auth.service';
 import { AuthPayload } from '../interfaces/token.interface';
 
-export type AuthRequest = Request & { usr?: User; account: Account };
-
 @Injectable()
-export class TokenStrategy extends PassportStrategy(Strategy) {
-  constructor(
-    private readonly accountService: AccountService,
-    private readonly userService: UserService,
-    private readonly config: ConfigService,
-  ) {
+export class TokenStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(authService: AuthService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      passReqToCallback: true,
-      secretOrKey: config.get('SECRET'),
+      secretOrKeyProvider: async function (
+        req: AuthRequest,
+        token: string,
+        done,
+      ) {
+        try {
+          return done(null, await authService.getSigningKey(req, token));
+        } catch (error) {
+          return done(error, null);
+        }
+      },
     });
   }
 
-  async validate(req: AuthRequest, payload: AuthPayload) {
-    if (!payload.iat || (!payload.aid && !payload.uid)) {
-      throw new UnauthorizedException('Malformed Token');
-    }
-
-    if (payload.uid) {
-      req.usr = await this.userService.findOne(payload.uid);
-
-      if (!req.usr) throw new UnauthorizedException('USER MISSING');
-      if (!req.usr.account) throw new InternalServerErrorException();
-
-      req.account = req.usr.account;
-    } else if (payload.aid) {
-      req.account = await this.accountService.findOne(payload.aid);
-
-      if (!req.account) throw new UnauthorizedException('ACC MISSING');
-    }
-
-    if (req.account.logoutAt) {
-      const logoutAt = req.account.logoutAt;
-      const issuedAt = new Date(payload.iat * 1000);
-
-      // Warning: The `iat` field on a JWT only has seconds precision.
-      // The results are unpredictable if someone were to try to rapidly
-      // use a token immediately after logging out. Thus the `>=`.
-      if (logoutAt >= issuedAt) {
-        throw new UnauthorizedException('Token Revoked');
-      }
-    }
-
-    return true;
+  validate(payload: AuthPayload) {
+    return payload;
   }
 }

--- a/src/backend/src/user/user.controller.ts
+++ b/src/backend/src/user/user.controller.ts
@@ -23,21 +23,21 @@ import { UserService } from './user.service';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @UseGuards(UserGuard)
-  @Get('me')
-  getMe(@Usr() user: User) {
-    return user;
-  }
-
   @Auth('user', 'create:own')
   @Post()
   create(@Acc() account: Account, @Body() createUserDTO: CreateUserDTO) {
     console.log(account, createUserDTO);
   }
 
+  @UseGuards(UserGuard)
+  @Get('me')
+  getMe(@Usr() user: User) {
+    return user;
+  }
+
   @Auth('user', 'update:any')
   @Patch(':id')
-  update(@Param() { id }: FindUserDTO, updateUserDTO: UpdateUserDTO) {
+  update(@Param() { id }: FindUserDTO, @Body() updateUserDTO: UpdateUserDTO) {
     return this.userService.update(id, updateUserDTO);
   }
 


### PR DESCRIPTION
This pull request is a potential fix to a precision issue with the issued-at field of the JSON web tokens. The `iat` field of the JWT only has second precision. If a user attempts to login within a second of logging out, the token generated will be considered invalid.

Two potential solutions are as follows:

1. Maintain the issue but flip the result. Essentially, instead of users logging in within the second after logout being invalid, ensure that any tokens within a 1 (or so) second range of the logout timestamp are permitted. This is simpler to fix, but creates annoyances in testing and an odd lag in the expectations of how this feature should work.
2. Don't compare dates, but instead append a random string to the universal secret when signing the JWT. This does not invoke further costs in the number of requests (though it is shifted earlier in the auth cycle), however it does require more computation, however small.